### PR TITLE
Make plugin compatible with Zepto

### DIFF
--- a/jquery.tablesort.js
+++ b/jquery.tablesort.js
@@ -27,6 +27,7 @@ $(function() {
 			var start = new Date(),
 				self = this,
 				table = this.$table,
+				body = table.find('tbody').length > 0 ? table.find('tbody') : table,
 				rows = this.$thead.length > 0 ? table.find('tbody tr') : table.find('tr').has('td'),
 				cells = table.find('tr td:nth-of-type(' + (th.index() + 1) + ')'),
 				sortBy = th.data().sortBy,
@@ -72,7 +73,7 @@ $(function() {
 			});
 
 			$.each(sortedMap, function(i, entry) {
-				table.append(entry.row);
+				body.append(entry.row);
 			});
 
 			th.addClass(self.settings[self.direction]);

--- a/jquery.tablesort.js
+++ b/jquery.tablesort.js
@@ -6,7 +6,7 @@
 
 $(function() {
 
-	var $ = window.jQuery;
+	var $ = window.Zepto || window.jQuery;
 
 	$.tablesort = function ($table, settings) {
 		var self = this;

--- a/zepto.html
+++ b/zepto.html
@@ -1,0 +1,145 @@
+<html>
+<head>
+	<title></title>
+	<style type="text/css">
+	body {
+		font: normal 14px/21px Arial, serif;
+	}
+	.example {
+		float: left;
+		width: 40%;
+		margin: 5%;
+	}
+	table {
+		font-size: 1em;
+		border-collapse: collapse;
+		margin: 0 auto
+	}
+	table, th, td {
+		border: 1px solid #999;
+		padding: 8px 16px;
+		text-align: left;
+	}
+	th {
+		background: #f4f4f4;
+		cursor: pointer;
+	}
+
+	th:hover,
+	th.sorted {
+		background: #d4d4d4;
+	}
+
+	th.sorted.ascending:after {
+		content: "  \2191";
+	}
+
+	th.sorted.descending:after {
+		content: " \2193";
+	}
+	</style>
+</head>
+<body>
+
+<div class="example ex-1">
+	<table>
+		<thead>
+			<tr>
+				<th>Name</th>
+				<th>Band</th>
+				<th>Date of Birth</th>
+				<th class="number">Age</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td>Thom Yorke</td>
+				<td>Radiohead</td>
+				<td data-sort-value="2">October 7, 1968</td>
+				<td>43</td>
+			</tr>
+			<tr>
+				<td>Justin Vernon</td>
+				<td>Bon Iver</td>
+				<td data-sort-value="4">April 30, 1981</td>
+				<td>30</td>
+			</tr>
+			<tr>
+				<td>Paul McCartney</td>
+				<td>The Beatles</td>
+				<td data-sort-value="1">June 18, 1942</td>
+				<td>69</td>
+			</tr>
+			<tr>
+				<td>Sam Beam</td>
+				<td>Iron &amp; Wine</td>
+				<td data-sort-value="3">July 26, 1974</td>
+				<td>37</td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>No <code>thead</code> or <code>tbody</code>; just <code>tr</code>s</p>
+	<table>
+			<tr>
+				<th>Name</th>
+				<th>Band</th>
+				<th>Date of Birth</th>
+				<th class="number">Age</th>
+			</tr>
+			<tr>
+				<td>Thom Yorke</td>
+				<td>Radiohead</td>
+				<td data-sort-value="2">October 7, 1968</td>
+				<td>43</td>
+			</tr>
+			<tr>
+				<td>Justin Vernon</td>
+				<td>Bon Iver</td>
+				<td data-sort-value="4">April 30, 1981</td>
+				<td>30</td>
+			</tr>
+			<tr>
+				<td>Paul McCartney</td>
+				<td>The Beatles</td>
+				<td data-sort-value="1">June 18, 1942</td>
+				<td>69</td>
+			</tr>
+			<tr>
+				<td>Sam Beam</td>
+				<td>Iron &amp; Wine</td>
+				<td data-sort-value="3">July 26, 1974</td>
+				<td>37</td>
+			</tr>
+	</table>
+
+</div>
+
+<div class="example ex-2"></div>
+
+<script src="http://f.cl.ly/items/2Q3A1w0X3p0q2N2f103B/zepto.js"></script>
+<script src="jquery.tablesort.js"></script>
+<script type="text/javascript">
+
+	$(function() {
+
+		var table = $('<table></table>');
+		table.append('<thead><tr><th class="number">Number</th></tr></thead>');
+		var tbody = $('<tbody></tbody>');
+		for(var i = 0; i<100; i++) {
+			tbody.append('<tr><td>' + Math.floor(Math.random() * 100) + '</td></tr>');
+		}
+		table.append(tbody);
+		$('.example.ex-2').append(table);
+
+		$('table').tablesort().data('tablesort');
+
+		$('thead th.number').data('sortBy', function(th, td, sorter) {
+			return parseInt(td.text(), 10);
+		});
+
+	});
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
I tried to use this plugin with [Zepto](http://zeptojs.com/) instead of jQuery and it didn't work. These changes make it compatible.

First things first: Zepto doesn't have a `.data()` method by default—you need to make a [custom build](https://github.com/madrobby/zepto#building) with the data module. I've linked to a version of Zepto including the data module in [zepto.html](https://github.com/elidupuis/jquery-tablesort/blob/zepto/zepto.html#L120). The plugin will still fail if the `.data()` module is missing.

For some reason, Zepto and jQuery append the `tr`s differently during a sort—jQuery manages to put them into the `tbody` but Zepto moves them out and they become siblings to the `tbody` (see screenshot). Your `rows` [variable](https://github.com/elidupuis/jquery-tablesort/blob/master/jquery.tablesort.js#L30) now returns an empty array when a `thead` exists. This PR addresses that issue.

![screen shot 2013-10-24 at 12 19 11 am](https://f.cloud.github.com/assets/196410/1396813/54a0acbe-3c74-11e3-9b5f-00469714f5b8.png)

Finally, it turns out that browsers actually [insert a `tbody` element](http://stackoverflow.com/questions/938083/why-do-browsers-insert-tbody-element-into-table-elements#answer-938143) if one does not exist so theoretically there will always be a `tbody`. I haven't looked into cross browser behavior on this topic.