### PR TITLE
Ignore Nested Tables

### DIFF
--- a/jquery.tablesort.js
+++ b/jquery.tablesort.js
@@ -13,7 +13,7 @@ $(function() {
 		this.$table = $table;
 		this.$thead = this.$table.find('thead');
 		this.settings = $.extend({}, $.tablesort.defaults, settings);
-		this.$sortCells = this.$thead.length > 0 ? this.$thead.find('th:not(.no-sort)') : this.$table.find('th:not(.no-sort)');
+		this.$sortCells = this.$thead.length > 0 ? this.$thead.find('th:not(.no-sort)').not('table table th') : this.$table.find('th:not(.no-sort)').not('table table th');
 		this.$sortCells.bind('click.tablesort', function() {
 			self.sort($(this));
 		});
@@ -29,8 +29,8 @@ $(function() {
 				self = this,
 				table = this.$table,
 				//body = table.find('tbody').length > 0 ? table.find('tbody') : table,
-				rows = this.$thead.length > 0 ? table.find('tbody tr') : table.find('tr').has('td'),
-				cells = table.find('tr td:nth-of-type(' + (th.index() + 1) + ')'),
+				rows = this.$thead.length > 0 ? table.find('tbody tr').not('table table tr') : table.find('tr').has('td').not('table table tr'),
+				cells = table.find('tr td:nth-of-type(' + (th.index() + 1) + ')').not('table table td'),
 				sortBy = th.data().sortBy,
 				sortedMap = [];
 


### PR DESCRIPTION
I had an issue where if I had a nested table, it would mess up everything. This can be expanded to be a setting later, but figured since this doesn't work with nested tables, lets just ignore them as a fix.