### PR TITLE
Added support for passing a 'compare' function used to sort

### DIFF
--- a/jquery.tablesort.js
+++ b/jquery.tablesort.js
@@ -70,13 +70,7 @@
 				}
 
 				sortedMap.sort(function(a, b) {
-					if (a.value > b.value) {
-						return 1 * direction;
-					} else if (a.value < b.value) {
-						return -1 * direction;
-					} else {
-						return 0;
-					}
+					return self.settings.compare(a.value, b.value) * direction;
 				});
 
 				$.each(sortedMap, function(i, entry) {
@@ -111,7 +105,16 @@
 	$.tablesort.defaults = {
 		debug: $.tablesort.DEBUG,
 		asc: 'sorted ascending',
-		desc: 'sorted descending'
+		desc: 'sorted descending',
+		compare: function(a, b) {
+			if (a > b) {
+				return 1;
+			} else if (a < b) {
+				return -1;
+			} else {
+				return 0;
+			}
+		}
 	};
 
 	$.fn.tablesort = function(settings) {


### PR DESCRIPTION
We've been using Semantic UI's Table component and your sort plugin but we needed alpha numeric sorting like what Dave Koelle outlined on his website here: http://www.davekoelle.com/alphanum.html.  With this changeset we can provide Dave's alpha-numeric sorting or any other custom compare function to your plugin.

Hope it helps 👍 
